### PR TITLE
HCF_AUTH and HCF_PROJECT_ID defaults to env variables

### DIFF
--- a/hcf_backend/backend.py
+++ b/hcf_backend/backend.py
@@ -77,7 +77,8 @@ from .utils import (
     convert_from_bytes,
     convert_to_bytes,
     assign_slotno,
-    get_project_id
+    get_project_id,
+    get_apikey
 )
 
 
@@ -122,7 +123,7 @@ class HCFBackend(Backend):
     def __init__(self, manager):
         self.manager = manager
 
-        self.hcf_auth = None
+        self.hcf_auth = get_apikey()
         self.hcf_project_id = get_project_id()
 
         self.hcf_producer_frontier = None

--- a/hcf_backend/utils/__init__.py
+++ b/hcf_backend/utils/__init__.py
@@ -2,6 +2,8 @@ import os
 import hashlib
 import six
 
+from scrapinghub.client import parse_auth
+
 
 def convert_from_bytes(data):
     if data is not None:
@@ -51,3 +53,11 @@ def get_project_id():
         return os.environ['SHUB_JOBKEY'].split('/')[0]
     except KeyError:
         pass
+
+
+def get_apikey():
+    """Provides a facade to the multiple behaviors of parse_auth() and forces
+    it to read the 'SH_APIKEY' env var and return it.
+    """
+
+    return parse_auth(None)[0]


### PR DESCRIPTION
Hi @kalessin 

This PR sets the defaults of the **settings** (in bold) to the `environment values`:

- **HCF_AUTH** to env: `SH_APIKEY` 
- **HCF_PROJECT_ID** to env: `SHUB_JOBKEY` (_first part only before_ `/`)

Thanks!