### PR TITLE
catch RuntimeError when SH_APIKEY env var is missing

### DIFF
--- a/hcf_backend/utils/__init__.py
+++ b/hcf_backend/utils/__init__.py
@@ -60,4 +60,7 @@ def get_apikey():
     it to read the 'SH_APIKEY' env var and return it.
     """
 
-    return parse_auth(None)[0]
+    try:
+        return parse_auth(None)[0]
+    except RuntimeError:
+        pass


### PR DESCRIPTION
Hi @kalessin 

I think I missed this part in my previous PR in https://github.com/scrapinghub/hcf-backend/pull/11/files
where I always encounter a `RuntimeError` in https://github.com/scrapinghub/python-scrapinghub/blob/master/scrapinghub/client/utils.py#L114
when the `SH_APIKEY` isn't set as an ENV var.

This PR catches the error and should return `None` instead (_implicitly_) which should allow us to override it in the `custom_settings`, specifically in the `HCF_AUTH` variable.

Cheers!
