### PR TITLE
add log msg for consumed batches of ids marked for deletion

### DIFF
--- a/hcf_backend/backend.py
+++ b/hcf_backend/backend.py
@@ -265,6 +265,7 @@ class HCFBackend(Backend):
     def delete_read_batches(self):
         if self.consumed_batches_ids:
             self.consumer.delete(self.hcf_consumer_slot, self.consumed_batches_ids)
+            LOG.info('Deleting read batches: %s', self.consumed_batches_ids)
         self.consumed_batches_ids = []
 
 


### PR DESCRIPTION
Hi @kalessin 

I'd like to request this very small change to add a log for `Batch IDs` marked for deletion.

We'll be playing around with `HCF_CONSUMER_DONT_DELETE_REQUESTS` and `HCF_CONSUMER_DELETE_BATCHES_ON_STOP` so it would be awesome to have something like this.

Cheers!