### PR TITLE
Add more retries and extend retry time

### DIFF
--- a/hcf_backend/utils/crawlmanager.py
+++ b/hcf_backend/utils/crawlmanager.py
@@ -8,6 +8,8 @@ import json
 import random
 import logging
 
+from scrapinghub import ScrapinghubClient
+
 from shub_workflow.crawl import CrawlManager
 
 from hcf_backend.utils.hcfpal import HCFPal
@@ -23,6 +25,7 @@ class HCFCrawlManager(CrawlManager):
 
     def __init__(self):
         super().__init__()
+        super.client = ScrapinghubClient(max_retries=10, max_retry_time=3600)
         self.hcfpal = HCFPal(self.client._hsclient.get_project(self.project_id))
 
     def add_argparser_options(self):


### PR DESCRIPTION
Suggesting extension of retry times and retry time window for `HCFCrawlManager`.
This would be helpful in cases of short API downtimes (API is usually up in 10 minutes), otherwise the manager dies after 3 retries in 60 s.
Since the managers are supposed to run for days, it would be better if they survived occasional API downtime.