### PR TITLE
fix convert_from_bytes to work with OrderedDict, UserDict, items...

### DIFF
--- a/hcf_backend/utils/__init__.py
+++ b/hcf_backend/utils/__init__.py
@@ -13,7 +13,7 @@ def convert_from_bytes(data):
         if data_type in (str, int, float, bool):
             return data
         if isinstance(data, collections.Mapping):
-            # Includes dict, OrderedDict, UserDict, items...
+            # Includes dict, OrderedDict, UserDict, scrapy.Item...
             data = data.items()
         return data_type(map(convert_from_bytes, data))
 

--- a/hcf_backend/utils/__init__.py
+++ b/hcf_backend/utils/__init__.py
@@ -1,4 +1,4 @@
-import os
+import collections
 import hashlib
 import six
 
@@ -12,7 +12,8 @@ def convert_from_bytes(data):
             return data.decode('utf8')
         if data_type in (str, int, float, bool):
             return data
-        if data_type == dict:
+        if isinstance(data, collections.Mapping):
+            # Includes dict, OrderedDict, UserDict, items...
             data = data.items()
         return data_type(map(convert_from_bytes, data))
 


### PR DESCRIPTION
Hi!

I've been trying to implement `shub-workflow`, that relies on this package, in a project and I was  getting this error:
```
dictionary update sequence element #0 has length 6; 2 is required
```
after long time debugging I found that the `convert_from_bytes` function was not correctly processing a `scrapy.Item` element.

This fix allows to pass `OrderedDict`, `UserDict`, `scrapy.Item`, etc.

Let me know if you need any extended example or to change something.