### PR TITLE
Frontera settings json

### DIFF
--- a/hcf_backend/__init__.py
+++ b/hcf_backend/__init__.py
@@ -1,4 +1,4 @@
 from .backend import *
 
 
-__version__ = '0.4.3.1'
+__version__ = '0.4.4'

--- a/hcf_backend/utils/crawlmanager.py
+++ b/hcf_backend/utils/crawlmanager.py
@@ -35,14 +35,6 @@ class HCFCrawlManager(CrawlManager):
     def description(self):
         return __doc__
 
-    def get_spider_args(self, override=None):
-        if self.args.frontera_settings_json is not None:
-            override = override or {}
-            override.update(
-                {"frontera-settings-json": self.args.frontera_settings_json}
-            )
-        return super().get_spider_args(override)
-
     def print_frontier_status(self):
         result = self.hcfpal.get_slots_count(self.args.frontier, self.args.prefix)
         logger.info(f"Frontier '{self.args.frontier}' status:")
@@ -85,13 +77,18 @@ class HCFCrawlManager(CrawlManager):
                 if not available_slots:
                     logger.info("Already running max number of jobs.")
 
+            base_frontera_settings = {}
+            if self.args.frontera_settings_json:
+                base_frontera_settings = json.loads(self.args.frontera_settings_json)
             for slot in available_slots:
-                frontera_settings_json = json.dumps(
+                frontera_settings = base_frontera_settings.copy()
+                frontera_settings.update(
                     {
                         "HCF_CONSUMER_SLOT": slot,
                         "HCF_CONSUMER_FRONTIER": self.args.frontier,
                     }
                 )
+                frontera_settings_json = json.dumps(frontera_settings)
                 logger.info(
                     f"Will schedule spider job with frontera settings {frontera_settings_json}"
                 )

--- a/hcf_backend/utils/crawlmanager.py
+++ b/hcf_backend/utils/crawlmanager.py
@@ -13,7 +13,7 @@ from shub_workflow.crawl import CrawlManager
 from hcf_backend.utils.hcfpal import HCFPal
 
 
-logging.basicConfig(format='%(message)s', level=logging.INFO)
+logging.basicConfig(format="%(message)s", level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -27,9 +27,9 @@ class HCFCrawlManager(CrawlManager):
 
     def add_argparser_options(self):
         super().add_argparser_options()
-        self.argparser.add_argument('frontier', help='Frontier name')
-        self.argparser.add_argument('prefix', help='Slot prefix')
-        self.argparser.add_argument('--frontera-settings-json')
+        self.argparser.add_argument("frontier", help="Frontier name")
+        self.argparser.add_argument("prefix", help="Slot prefix")
+        self.argparser.add_argument("--frontera-settings-json")
 
     @property
     def description(self):
@@ -38,36 +38,44 @@ class HCFCrawlManager(CrawlManager):
     def get_spider_args(self, override=None):
         if self.args.frontera_settings_json is not None:
             override = override or {}
-            override.update({
-                'frontera-settings-json': self.args.frontera_settings_json
-            })
+            override.update(
+                {"frontera-settings-json": self.args.frontera_settings_json}
+            )
         return super().get_spider_args(override)
 
     def print_frontier_status(self):
         result = self.hcfpal.get_slots_count(self.args.frontier, self.args.prefix)
         logger.info(f"Frontier '{self.args.frontier}' status:")
-        for slot in sorted(result['slots'].keys()):
-            cnt_text = '\t{}: {}'.format(slot, result['slots'][slot])
+        for slot in sorted(result["slots"].keys()):
+            cnt_text = "\t{}: {}".format(slot, result["slots"][slot])
             logger.info(cnt_text)
-        logger.info('\tTotal count: {}'.format(humanize.intcomma(result['total'])))
+        logger.info("\tTotal count: {}".format(humanize.intcomma(result["total"])))
 
-        return set(result['slots'].keys())
+        return set(result["slots"].keys())
 
     def workflow_loop(self):
         available_slots = self.print_frontier_status()
 
         running_jobs = 0
-        states = 'running', 'pending'
+        states = "running", "pending"
         for state in states:
-            for job in self.get_project().jobs.list(spider=self.args.spider, state=state, meta='spider_args'):
-                frontera_settings_json = json.loads(job['spider_args'].get('frontera_settings_json', '{}'))
-                if 'HCF_CONSUMER_SLOT' in frontera_settings_json:
-                    slot = frontera_settings_json['HCF_CONSUMER_SLOT']
+            for job in self.get_project().jobs.list(
+                spider=self.args.spider, state=state, meta="spider_args"
+            ):
+                frontera_settings_json = json.loads(
+                    job["spider_args"].get("frontera_settings_json", "{}")
+                )
+                if "HCF_CONSUMER_SLOT" in frontera_settings_json:
+                    slot = frontera_settings_json["HCF_CONSUMER_SLOT"]
                     if slot in available_slots:
                         available_slots.discard(slot)
                         running_jobs += 1
 
-        available_slots = [slot for slot in available_slots if self.hcfpal.get_slot_count(self.args.frontier, slot) > 0]
+        available_slots = [
+            slot
+            for slot in available_slots
+            if self.hcfpal.get_slot_count(self.args.frontier, slot) > 0
+        ]
         logger.info(f"Available slots: {available_slots!r}")
         if available_slots:
             random.shuffle(available_slots)
@@ -78,17 +86,27 @@ class HCFCrawlManager(CrawlManager):
                     logger.info("Already running max number of jobs.")
 
             for slot in available_slots:
-                frontera_settings_json = json.dumps({
-                    'HCF_CONSUMER_SLOT': slot,
-                    'HCF_CONSUMER_FRONTIER': self.args.frontier,
-                })
-                logger.info(f"Will schedule spider job with frontera settings {frontera_settings_json}")
-                jobkey = self.schedule_spider(spider_args_override={'frontera_settings_json': frontera_settings_json})
-                logger.info(f"Scheduled job {jobkey} with frontera settings {frontera_settings_json}")
+                frontera_settings_json = json.dumps(
+                    {
+                        "HCF_CONSUMER_SLOT": slot,
+                        "HCF_CONSUMER_FRONTIER": self.args.frontier,
+                    }
+                )
+                logger.info(
+                    f"Will schedule spider job with frontera settings {frontera_settings_json}"
+                )
+                jobkey = self.schedule_spider(
+                    spider_args_override={
+                        "frontera_settings_json": frontera_settings_json
+                    }
+                )
+                logger.info(
+                    f"Scheduled job {jobkey} with frontera settings {frontera_settings_json}"
+                )
             return True
         return bool(running_jobs)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     manager = HCFCrawlManager()
     manager.run()

--- a/hcf_backend/utils/crawlmanager.py
+++ b/hcf_backend/utils/crawlmanager.py
@@ -29,10 +29,19 @@ class HCFCrawlManager(CrawlManager):
         super().add_argparser_options()
         self.argparser.add_argument('frontier', help='Frontier name')
         self.argparser.add_argument('prefix', help='Slot prefix')
+        self.argparser.add_argument('--frontera-settings-json')
 
     @property
     def description(self):
         return __doc__
+
+    def get_spider_args(self, override=None):
+        if self.args.frontera_settings_json is not None:
+            override = override or {}
+            override.update(
+                'frontera-settings-json': self.args.frontera_settings_json
+            )
+        return super().get_spider_args(override)
 
     def workflow_loop(self):
         slot_re = re.compile(rf"{self.args.prefix}\d+")

--- a/hcf_backend/utils/crawlmanager.py
+++ b/hcf_backend/utils/crawlmanager.py
@@ -1,5 +1,5 @@
 """
-Script for easy managing of consumer spiders from multiple slots. It checks available slots and schedules
+shub-workflow based script (runs on Zyte ScrapyCloud) for easy managing of consumer spiders from multiple slots. It checks available slots and schedules
 a job for each one.
 """
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name         = 'hcf-backend',
-    version      = '0.4.3.1',
+    version      = '0.4.4',
     description  = 'ScrapyCloud HubStorage frontier backend for Frontera',
     long_description = open('README.md').read(),
     license      = 'BSD',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name         = 'hcf-backend',
     version      = '0.4.3.1',
     description  = 'ScrapyCloud HubStorage frontier backend for Frontera',
-    long_description = open('README.rst').read(),
+    long_description = open('README.md').read(),
     license      = 'BSD',
     url          = 'https://github.com/scrapinghub/hcf-backend',
     maintainer   ='Scrapinghub',


### PR DESCRIPTION
crawlmanager: Allow to pass frontera-settings-json using command line, in order to avoid to manually adapt into spider arguments.